### PR TITLE
BACKLOG-12866: Add toggleNode to TreeView onClickItem prop

### DIFF
--- a/src/javascript/Administration/Administration.jsx
+++ b/src/javascript/Administration/Administration.jsx
@@ -157,7 +157,12 @@ const Administration = ({match}) => {
                                       data={serverResult.data}
                                       selectedItems={serverSelectedItem ? [serverSelectedItem] : []}
                                       defaultOpenedItems={serverResult.defaultOpenedItems}
-                                      onClickItem={elt => elt.isSelectable && history.push('/administration/' + elt.id)}/>
+                                      onClickItem={
+                                          (elt, event, toggleNode) => (
+                                              elt.isSelectable ?
+                                                  history.push('/administration/' + elt.id) :
+                                                  toggleNode(event))
+                                      }/>
                         </AccordionItem>}
                         {sitesResult.allowed &&
                         <AccordionItem id={constants.ACCORDION_TABS.SITE}
@@ -169,7 +174,12 @@ const Administration = ({match}) => {
                                       data={sitesResult.data}
                                       selectedItems={siteSelectedItem ? [siteSelectedItem] : []}
                                       defaultOpenedItems={sitesResult.defaultOpenedItems}
-                                      onClickItem={elt => elt.isSelectable && history.push('/administration/' + currentSite + '/' + elt.id)}/>
+                                      onClickItem={
+                                          (elt, event, toggleNode) => (
+                                              elt.isSelectable ?
+                                                  history.push('/administration/' + currentSite + '/' + elt.id) :
+                                                  toggleNode(event))
+                                      }/>
                         </AccordionItem>}
                     </Accordion>
                 </SecondaryNav>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12866

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

The onClickItem prop for the TreeView component now uses the toggleNode method which is passed through to toggle open/close of the node if it's not selectable as per the data object.

This PR cannot be merged until the supporting change from MOON-131 is included in a Moonstone release.