### PR TITLE
BACKLOG-14907: Allows to add route entries which do not appear in menu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <properties>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFB9MYWN7bdGc5pIZs6fNhhQaIrYcAhQW563Bpkfb/uvVndTkBLJeQiIp9A==</jahia-module-signature>
+        <jahia-module-signature>MCwCFGL1jIk8kB6yybW4v0swWLx0371rAhQUiHdo2JJnSeoEv9/RHKfeLQHVBg==</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
     </properties>
 

--- a/src/javascript/Administration/Administration.jsx
+++ b/src/javascript/Administration/Administration.jsx
@@ -55,6 +55,7 @@ const useTree = ({target, nodePath, mainPermission, selectedItem}) => {
     const data = tree
         .filter(route => route.requiredPermission === undefined || node[route.requiredPermission] !== false)
         .filter(route => route.requireModuleInstalledOnSite === undefined || node.site.installedModulesWithAllDependencies.indexOf(route.requireModuleInstalledOnSite) > -1)
+        .filter(route => !route.routeOnly)
         .map(route => ({
             id: route.key,
             label: t(route.label),
@@ -83,6 +84,9 @@ const useTree = ({target, nodePath, mainPermission, selectedItem}) => {
 function getSelectedItem(param) {
     let item = param.substr(1);
     if (registry.get('adminRoute', item)) {
+        while (registry.get('adminRoute', item).routeOnly && item.indexOf('/') > 0) {
+            item = item.substr(0, item.lastIndexOf('/'))
+        }
         return {serverSelectedItem: item};
     }
 
@@ -90,6 +94,9 @@ function getSelectedItem(param) {
     let site = spl[0];
     item = spl.slice(1).join('/');
     if (registry.get('adminRoute', item)) {
+        while (registry.get('adminRoute', item).routeOnly && item.indexOf('/') > 0) {
+            item = item.substr(0, item.lastIndexOf('/'))
+        }
         return {site, siteSelectedItem: item};
     }
 

--- a/src/javascript/Administration/Administration.jsx
+++ b/src/javascript/Administration/Administration.jsx
@@ -85,8 +85,9 @@ function getSelectedItem(param) {
     let item = param.substr(1);
     if (registry.get('adminRoute', item)) {
         while (registry.get('adminRoute', item).routeOnly && item.indexOf('/') > 0) {
-            item = item.substr(0, item.lastIndexOf('/'))
+            item = item.substr(0, item.lastIndexOf('/'));
         }
+
         return {serverSelectedItem: item};
     }
 
@@ -95,8 +96,9 @@ function getSelectedItem(param) {
     item = spl.slice(1).join('/');
     if (registry.get('adminRoute', item)) {
         while (registry.get('adminRoute', item).routeOnly && item.indexOf('/') > 0) {
-            item = item.substr(0, item.lastIndexOf('/'))
+            item = item.substr(0, item.lastIndexOf('/'));
         }
+
         return {site, siteSelectedItem: item};
     }
 


### PR DESCRIPTION

https://jira.jahia.org/browse/BACKLOG-14907

## Description

Adding routeOnly to a route will not display it in the tree. The parent item will be selected in the tree, if available.
It would be nice to have this code directly  in useAdminRouteTreeStructure(), but the getSelectedItem part is not easy to move.