### PR TITLE
BACKLOG-16607: Fix/reset color scheme on nav dropdown search input

### DIFF
--- a/src/javascript/Administration/SiteSwitcher/SiteSwitcher.scss
+++ b/src/javascript/Administration/SiteSwitcher/SiteSwitcher.scss
@@ -2,4 +2,10 @@
     flex: 1;
 
     text-transform: capitalize;
+
+    [role="listbox"] input,
+    [role="listbox"] svg {
+        /* Reset .moonstone-reversed color scheme on dropdown search input */
+        color: initial;
+    }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16607

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue where side nav has a moonstone-reversed color scheme and making dropdown search input look like this:

![image](https://user-images.githubusercontent.com/75278792/218168407-484c9aac-da01-4483-b807-e99b31754fb3.png)

vs fixed: 

![image](https://user-images.githubusercontent.com/75278792/218168340-cfe9b5be-bb42-461f-b078-280d38248ab4.png)

Related PR (jcontent): https://github.com/Jahia/jcontent/pull/702