### PR TITLE
fix: Drive admin accordion with redux

### DIFF
--- a/src/javascript/Administration/Administration.jsx
+++ b/src/javascript/Administration/Administration.jsx
@@ -13,6 +13,7 @@ import {batch, useDispatch, useSelector, shallowEqual} from 'react-redux';
 import SiteSwitcher from './SiteSwitcher/SiteSwitcher';
 import PropTypes from 'prop-types';
 import AdministrationEmpty from './Administration.empty';
+import {adminSetAccordion} from './Administration.redux';
 
 let current;
 let dispatch;
@@ -119,7 +120,8 @@ const Administration = ({match}) => {
 
     current = useSelector(state => ({
         site: state.site,
-        language: state.language
+        language: state.language,
+        currentAccordionItem: state.administration.accordion
     }), shallowEqual);
     dispatch = useDispatch();
 
@@ -166,11 +168,12 @@ const Administration = ({match}) => {
         <LayoutModule
             navigation={
                 <SecondaryNav header={<SecondaryNavHeader>{t('jahia-administration:jahia-administration.label')}</SecondaryNavHeader>}>
-                    <Accordion isReversed defaultOpenedItem={accordionOpenTab}>
+                    <Accordion isReversed defaultOpenedItem={accordionOpenTab} openedItem={current.currentAccordionItem !== '' ? current.currentAccordionItem : accordionOpenTab}>
                         {serverResult.allowed &&
                         <AccordionItem id={constants.ACCORDION_TABS.SERVER}
                                        label={t('jahia-administration:jahia-administration.server')}
                                        icon={<Server/>}
+                                       onClick={() => dispatch(adminSetAccordion(constants.ACCORDION_TABS.SERVER))}
                         >
                             <TreeView isReversed
                                       data={serverResult.data}
@@ -187,6 +190,7 @@ const Administration = ({match}) => {
                         <AccordionItem id={constants.ACCORDION_TABS.SITE}
                                        label={t('jahia-administration:jahia-administration.sites')}
                                        icon={<SiteWeb/>}
+                                       onClick={() => dispatch(adminSetAccordion(constants.ACCORDION_TABS.SITE))}
                         >
                             <SiteSwitcher selectedItem={siteSelectedItem} availableRoutes={sitesResult.filteredRoutes}/>
                             <TreeView isReversed

--- a/src/javascript/Administration/Administration.redux.js
+++ b/src/javascript/Administration/Administration.redux.js
@@ -2,7 +2,7 @@ import {createActions, handleActions} from 'redux-actions';
 import {registry} from '@jahia/ui-extender';
 import {combineReducers} from 'redux';
 
-export const {adminSetPath} = createActions('ADMIN_SET_PATH');
+export const {adminSetPath, adminSetAccordion} = createActions('ADMIN_SET_PATH', 'ADMIN_SET_ACCORDION');
 
 const extractParamsFromUrl = pathname => {
     if (pathname.startsWith('/administration/')) {
@@ -26,8 +26,12 @@ export const administrationRedux = () => {
         '@@router/LOCATION_CHANGE': (state, action) => action.payload.location.pathname.startsWith('/administration') ? extractParamsFromUrl(action.payload.location.pathname).path : state
     }, currentValueFromUrl.path);
 
+    const accordionReducer = handleActions({
+        [adminSetAccordion]: (state, action) => action.payload
+    }, '');
+
     registry.add('redux-reducer', 'administration', {
         targets: ['root'],
-        reducer: combineReducers({path: pathReducer})
+        reducer: combineReducers({path: pathReducer, accordion: accordionReducer})
     });
 };


### PR DESCRIPTION
### Description
Drive admin accordion with redux to be able to go back to the same selection if the layout tree reloads. The layout will reload when site changes and there are no results from node info query and nothing in cache. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
